### PR TITLE
Check banned chars when parsing documents

### DIFF
--- a/pkg/gedcom7/document.go
+++ b/pkg/gedcom7/document.go
@@ -86,8 +86,10 @@ func NewDocument(s *bufio.Scanner, options ...DocOptions) *document {
 			doc.AddWarning(line, fmt.Sprintf("Line %d: invalid tag %s", i, line.Tag))
 		}
 
-		if !line.Validate() {
-			doc.AddWarning(line, fmt.Sprintf("Line %d: invalid payload %s", i, line.Payload))
+		if errors := line.Validate(); len(errors) > 0 {
+			for _, e := range errors {
+				doc.AddWarning(e, fmt.Sprintf("Line %d: %s", i, line.Payload))
+			}
 		}
 
 		switch line.Level {

--- a/pkg/gedcom7/line.go
+++ b/pkg/gedcom7/line.go
@@ -101,20 +101,22 @@ func (l *Line) String() string {
 }
 
 // Validate checks the Line elements for technical errors.
-func (l *Line) Validate() bool {
+func (l *Line) Validate() []string {
+	errors := make([]string, 0)
 	if l.Level < 0 {
-		return false
+		errors = append(errors, fmt.Sprintf("Level %d must be positive", l.Level))
 	}
 	if !regTag.MatchString(l.Tag) {
-		return false
+		errors = append(errors, fmt.Sprintf("Tag %s contains invalid characters", l.Tag))
 	}
 	if l.Xref != "" && !gc70val.IsXref(l.Xref) {
-		return false
+		errors = append(errors, fmt.Sprintf("Xref %s not properly formatted", l.Xref))
 	}
-	if regBanned.MatchString(l.Payload) {
-		return false
+	if regBanned.MatchString(l.Text) {
+		errors = append(errors, fmt.Sprintf("Line %s contains banned characters", l.Text))
 	}
-	return true
+
+	return errors
 }
 
 // Matches evaluates each line.Text using fn() with `pattern` and returns a slice of matching lines.

--- a/pkg/gedcom7/line_test.go
+++ b/pkg/gedcom7/line_test.go
@@ -254,7 +254,7 @@ func TestToLine(t *testing.T) {
 	}
 }
 
-func TestNewlineFromFile(t *testing.T) {
+func TestNewlinesFromFile(t *testing.T) {
 	tests := []struct {
 		name      string
 		file      string

--- a/pkg/gedcom7/validate.go
+++ b/pkg/gedcom7/validate.go
@@ -24,8 +24,8 @@ func (d *document) Validate() error {
 // TODO Still need to verify the node is validly placed in the document tree.
 func (d *document) ValidateNode(node gedcom.Node) error {
 	line := node.GetValue().(*Line)
-	if ok := line.Validate(); !ok {
-		return fmt.Errorf("line validation failed sanity check")
+	if v := line.Validate(); len(v) > 0 {
+		return fmt.Errorf("line validator logged %d errors", len(v))
 	}
 	enums := d.Validator.GetEnums(line.Tag)
 	if enums != nil {


### PR DESCRIPTION
Also returns a list of errors and warnings when validating nodes. These errors are added to the document struct.